### PR TITLE
[IE CLDNN] Fix DetectionOutput cldnn unittest failure

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/detection_output.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/detection_output.hpp
@@ -63,7 +63,7 @@ class DetectionOutputLayerTest : public testing::WithParamInterface<DetectionOut
     ngraph::op::DetectionOutputAttrs attrs;
     std::vector<InferenceEngine::SizeVector> inShapes;
     void GenerateInputs() override;
-    void Compare(const std::vector<std::uint8_t> &expected, const InferenceEngine::Blob::Ptr &actual) override;
+    void Compare(const std::vector<std::vector<std::uint8_t>> &expectedOutputs, const std::vector<InferenceEngine::Blob::Ptr> &actualOutputs) override;
   protected:
     void SetUp() override;
 };

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/detection_output.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/detection_output.cpp
@@ -90,32 +90,38 @@ void DetectionOutputLayerTest::GenerateInputs() {
     }
 }
 
-void DetectionOutputLayerTest::Compare(const std::vector<std::uint8_t> &expected, const InferenceEngine::Blob::Ptr &actual) {
-    ASSERT_EQ(expected.size(), actual->byteSize());
+void DetectionOutputLayerTest::Compare(const std::vector<std::vector<std::uint8_t>> &expectedOutputs,
+                                       const std::vector<InferenceEngine::Blob::Ptr> &actualOutputs) {
+    for (std::size_t outputIndex = 0; outputIndex < expectedOutputs.size(); ++outputIndex) {
+        const auto &expected = expectedOutputs[outputIndex];
+        const auto &actual = actualOutputs[outputIndex];
 
-    size_t expSize = 0;
-    size_t actSize = 0;
+        ASSERT_EQ(expected.size(), actual->byteSize());
 
-    const auto &expectedBuffer = expected.data();
-    auto memory = InferenceEngine::as<InferenceEngine::MemoryBlob>(actual);
-    IE_ASSERT(memory);
-    const auto lockedMemory = memory->wmap();
-    const auto actualBuffer = lockedMemory.as<const std::uint8_t *>();
+        size_t expSize = 0;
+        size_t actSize = 0;
 
-    const float *expBuf = reinterpret_cast<const float *>(expectedBuffer);
-    const float *actBuf = reinterpret_cast<const float *>(actualBuffer);
-    for (size_t i = 0; i < actual->size(); i+=7) {
-        if (expBuf[i] == -1)
-            break;
-        expSize += 7;
+        const auto &expectedBuffer = expected.data();
+        auto memory = InferenceEngine::as<InferenceEngine::MemoryBlob>(actual);
+        IE_ASSERT(memory);
+        const auto lockedMemory = memory->wmap();
+        const auto actualBuffer = lockedMemory.as<const std::uint8_t *>();
+
+        const float *expBuf = reinterpret_cast<const float *>(expectedBuffer);
+        const float *actBuf = reinterpret_cast<const float *>(actualBuffer);
+        for (size_t i = 0; i < actual->size(); i+=7) {
+            if (expBuf[i] == -1)
+                break;
+            expSize += 7;
+        }
+        for (size_t i = 0; i < actual->size(); i+=7) {
+            if (actBuf[i] == -1)
+                break;
+            actSize += 7;
+        }
+        ASSERT_EQ(expSize, actSize);
+        LayerTestsCommon::Compare<float>(expBuf, actBuf, expSize, 1e-2f);
     }
-    for (size_t i = 0; i < actual->size(); i+=7) {
-        if (actBuf[i] == -1)
-            break;
-        actSize += 7;
-    }
-    ASSERT_EQ(expSize, actSize);
-    LayerTestsCommon::Compare<float>(expBuf, actBuf, expSize, 1e-2f);
 }
 
 void DetectionOutputLayerTest::SetUp() {


### PR DESCRIPTION
### Details:
 - Fixed unittest failure when the total number of detections is less than keep_top_k
 - Fixed unittest failure if there is input padding
 - Update overrided compare function for fixing gpuFuncTest failure

### Tickets:
 - 45293
